### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ with open(os.path.join(SRC, 'generic', 'meta.py'), 'w') as F:
     F.write(
         '# Auto-generated file. Please do not edit\n'
         '__version__ = %r\n' % VERSION +
-        '__author__ = %r\n' % AUTHOR)
+        '__author__ = {0!r}\n'.format(AUTHOR))
 
 
 #

--- a/src/generic/conversion.py
+++ b/src/generic/conversion.py
@@ -74,15 +74,15 @@ def get_conversion(from_type, to_type):
             if issubclass(to_type, from_type):
                 return _do_nothing
         except TypeError:
-            raise ValueError('not types: %r, %r' % (from_type, to_type))
+            raise ValueError('not types: {0!r}, {1!r}'.format(from_type, to_type))
 
     # Handle key error
     if not (isinstance(from_type, Type) and isinstance(to_type, Type)):
         print(Type)
         fmt = type(from_type).__name__, type(to_type).__name__
-        raise ValueError('not types: %r, %r' % (from_type, to_type))
+        raise ValueError('not types: {0!r}, {1!r}'.format(from_type, to_type))
     fmt = from_type.__name__, to_type.__name__
-    msg = "cannot convert '%s' to '%s'" % fmt
+    msg = "cannot convert '{0!s}' to '{1!s}'".format(*fmt)
     raise TypeError(msg)
 
 
@@ -116,7 +116,7 @@ def set_conversion(from_type, to_type, function=None):
     # Forbid redefinitions
     if (from_type, to_type) in CONVERT_FUNCTIONS:
         fmt = from_type.__name__, to_type.__name__
-        raise ValueError('cannot overwrite convertion from %s to %s' % fmt)
+        raise ValueError('cannot overwrite convertion from {0!s} to {1!s}'.format(*fmt))
 
     CONVERT_FUNCTIONS[from_type, to_type] = function
 
@@ -243,12 +243,12 @@ def _compute_promotions(T1, T2):
             return get_promotion(T2, T1)
         else:
             aux = (T1.__name__, T2.__name__)
-            raise TypeError('no promotion rule found for %s and %s' % aux)
+            raise TypeError('no promotion rule found for {0!s} and {1!s}'.format(*aux))
 
     # More than one rule was found
     elif len(valid) > 1:
         aux = (T1.__name__, T2.__name__)
-        raise TypeError('ambiguous promotion found for %s and %s' % aux)
+        raise TypeError('ambiguous promotion found for {0!s} and {1!s}'.format(*aux))
 
     # A single promotion was found
     else:
@@ -295,7 +295,7 @@ def set_promotion(T1, T2, *,
     if (T1, T2) in PROMOTION_FUNCTIONS or (symmetric and (T2, T1) in PROMOTION_FUNCTIONS):
         out_name = restype.__name__ if restype else (function.__name__ + '()')
         fmt = T1.__name__, T2.__name__, out_name
-        msg = 'cannot overwrite promotion rule: (%s, %s) --> %s' % fmt
+        msg = 'cannot overwrite promotion rule: ({0!s}, {1!s}) --> {2!s}'.format(*fmt)
         raise RuntimeError(msg)
 
     PROMOTION_FUNCTIONS[T1, T2] = function
@@ -319,7 +319,7 @@ def set_promotion_rule(T1, T2, T3):
     if (T1, T2) in PROMOTION_FUNCTIONS or (T2, T1) in PROMOTION_FUNCTIONS:
         fmt = T1.__name__, T2.__name__, T3.__name__
         raise RuntimeError(
-            'cannot overwrite promotion rule: (%s, %s) --> %s' % fmt)
+            'cannot overwrite promotion rule: ({0!s}, {1!s}) --> {2!s}'.format(*fmt))
 
     # Check trivial promotion
     if T1 is T2:
@@ -372,7 +372,7 @@ def promote_type(T1, T2):
             return T1
         else:
             fmt = T1.__name__, T2.__name__
-            raise TypeError('no promotion rule for (%s, %s)' % fmt)
+            raise TypeError('no promotion rule for ({0!s}, {1!s})'.format(*fmt))
 
 
 #

--- a/src/generic/core.py
+++ b/src/generic/core.py
@@ -61,13 +61,13 @@ class Generic(_generic_base):
             except KeyError:
                 raise no_methods_error(self, types=types)
         if method is None:
-            raise TypeError('no fallback defined for %s()' % self.__name__)
+            raise TypeError('no fallback defined for {0!s}()'.format(self.__name__))
         return method(*args, **kwds)
 
     def __repr__(self):
         name = self.name
         size = len(self)
-        return '<generic function %(name)s() with %(size)s methods>' % locals()
+        return '<generic function {name!s}() with {size!s} methods>'.format(**locals())
 
     def __get__(self, instance, cls=None):
         """Makes it work as a method"""
@@ -186,7 +186,7 @@ class Generic(_generic_base):
         Raises a TypeError if no suitable implementation is found."""
 
         if not all(isinstance(T, type) for T in argtypes):
-            raise TypeError('dispatch expect types, got: %r' % argtypes)
+            raise TypeError('dispatch expect types, got: {0!r}'.format(argtypes))
 
         registry = self._registry
         while True:
@@ -236,7 +236,7 @@ class Generic(_generic_base):
         try:
             return self[types]
         except KeyError:
-            raise TypeError('no methods for %s' % types)
+            raise TypeError('no methods for {0!s}'.format(types))
     
     def register(self, *argtypes, **kwds):
         """Register a new implementation for the given sequence of input
@@ -250,7 +250,7 @@ class Generic(_generic_base):
         
         if kwds:
             arg = kwds.popitem()[0]
-            raise TypeError('invalid keyword argument: %s' % arg)
+            raise TypeError('invalid keyword argument: {0!s}'.format(arg))
         
         # We don't use the restype for now. Maybe in the future? Ideas?
         if func is None:
@@ -286,16 +286,16 @@ class Generic(_generic_base):
         if argtypes is not None:
             if not all(isinstance(T, type) for T in argtypes):
                 argtypes = str(argtypes)
-                raise ValueError('must be a tuple of types, got %s' % argtypes)
+                raise ValueError('must be a tuple of types, got {0!s}'.format(argtypes))
         if not isinstance(restype, (type, type(None))):
             tname = type(restype).__name__
-            raise ValueError('return type must be a type, got %s' % tname)
+            raise ValueError('return type must be a type, got {0!s}'.format(tname))
 
         # Prevent overwriting old values
         if argtypes in self._registry:
             types_repr = ', '.join(T.__name__ for T in argtypes)
             name = self.name
-            msg = 'method %s(%s) is already defined' % (name, types_repr)
+            msg = 'method {0!s}({1!s}) is already defined'.format(name, types_repr)
             raise TypeError(msg)
 
         # Add keys and update cache
@@ -437,7 +437,7 @@ def dispatch(T, options, fname='function'):
         if len(parents) != 1:
             msg = 'ambiguous dispatch. Could not chose between these methods:'
             for args in parents:
-                sig = '%s(%s)' % (fname, ', '.join(T.__name__ for T in args))
+                sig = '{0!s}({1!s})'.format(fname, ', '.join(T.__name__ for T in args))
                 msg += '\n    * ' + sig
             raise DispatchError(msg)
 
@@ -476,7 +476,7 @@ def generic(*args, **kwds):
     else:
         def decorator(func):
             if not callable(func):
-                msg = 'must decorate function, got: %s' % type(func).__name__
+                msg = 'must decorate function, got: {0!s}'.format(type(func).__name__)
                 raise TypeError(msg)
             return generic(func, *args, **kwds)
         return decorator
@@ -616,7 +616,7 @@ def _restype_checker_factory(func, argtypes, restype):
     def checked(*args, **kwds):
         out = func(*args, **kwds)
         if not isinstance(out, restype):
-            raise TypeError('wrong return type: %s' % tname(out))
+            raise TypeError('wrong return type: {0!s}'.format(tname(out)))
         return out
                  
     return checked
@@ -653,7 +653,7 @@ def _instance_check_factory(func, argtypes, restype, instancecheck=isinstance):
         else:
             out = func(*args, **kwds)
             if not instancecheck(out, restype):
-                raise TypeError('wrong return type: %s' % tname(out))
+                raise TypeError('wrong return type: {0!s}'.format(tname(out)))
             return out
                  
     return checked

--- a/src/generic/errors.py
+++ b/src/generic/errors.py
@@ -27,10 +27,10 @@ def no_methods_error(func, args=None, types=None):
     name = func if isinstance(func, str) else getattr(func, '__name__', func)
 
     if types is None:
-        return DispatchError('invalid call to %s()' % func)
+        return DispatchError('invalid call to {0!s}()'.format(func))
     else:
         data = ', '.join(T.__name__ for T in types)
-        return DispatchError('no method found for %s(%s)' % (name, data))
+        return DispatchError('no method found for {0!s}({1!s})'.format(name, data))
 
 
 def raise_no_methods(func, args=None, types=None):
@@ -53,7 +53,7 @@ def get_unordered_types_error(T1, T2):
     ordered."""
 
     names = T1.__name__, T2.__name__
-    return TypeError('there is no order relation for %s and %s.' % names)
+    return TypeError('there is no order relation for {0!s} and {1!s}.'.format(*names))
 
 
 def raise_unordered(x, y):

--- a/src/generic/fasttrack.py
+++ b/src/generic/fasttrack.py
@@ -341,13 +341,13 @@ class TimedMultiFunction(MultiFunction):
         if sort_by == 'time':
             L = sorted(self._timings.items(), key=lambda x: x[1])
         else:
-            raise ValueError('invalid sort method: %r' % sort_by)
+            raise ValueError('invalid sort method: {0!r}'.format(sort_by))
 
         # Print it
-        msg = 'Performance test for %s()' % self.name
+        msg = 'Performance test for {0!s}()'.format(self.name)
         print(msg + '\n' + '-' * len(msg), '\n')
         for name, time in L:
-            print('    %s: %s sec' % (name, time))
+            print('    {0!s}: {1!s} sec'.format(name, time))
 
 
 #==============================================================================
@@ -404,7 +404,7 @@ def haslib(libname, func=None, descr=None):
     (2+0j)
     '''
     if descr:
-        libname = '%s (%s)' % (libname, descr)
+        libname = '{0!s} ({1!s})'.format(libname, descr)
 
     def decorator(func):
         global JOB
@@ -513,7 +513,7 @@ def try_import(*args, **kwargs):
     elif 'raises' in kwargs:
         raises = kwargs['raises']
     else:
-        raise TypeError('invalid keyword argument: %s' % kwargs.popitem()[0])
+        raise TypeError('invalid keyword argument: {0!s}'.format(kwargs.popitem()[0]))
 
     # Import modules in sequence
     for module in args:
@@ -583,7 +583,7 @@ def timeit(title=None):
     delta = gettime() - t0
     out.value = delta
     if title is not None:
-        print('%s: %s sec' % (title, delta))
+        print('{0!s}: {1!s} sec'.format(title, delta))
 
 #==============================================================================
 # Late binding

--- a/src/generic/op.py
+++ b/src/generic/op.py
@@ -161,7 +161,7 @@ def _opsame_meta_factory(opname):
     """Returns a factory tha can be used to test if the object implements a 
     __<opname>same__() method"""
     
-    samemethod = '__%ssame__' % opname
+    samemethod = '__{0!s}same__'.format(opname)
 
     def factory(argtypes, restype):
         T1, T2 = argtypes
@@ -182,8 +182,8 @@ def _opsame_meta_factory(opname):
 def _arithmetic_op_factory(opname):
     """Creates a generic arithmetic operator with the given name"""
     
-    method = '__%s__' % opname
-    rmethod = '__r%s__' % opname
+    method = '__{0!s}__'.format(opname)
+    rmethod = '__r{0!s}__'.format(opname)
     
     @generic
     def op(x, y):
@@ -235,8 +235,8 @@ lshift = _arithmetic_op_factory('lshift')
 def _relational_op_factory(opname, ropname):
     """Creates a generic arithmetic operator with the given name"""
 
-    method = '__%s__' % opname
-    rmethod = '__%s__' % ropname
+    method = '__{0!s}__'.format(opname)
+    rmethod = '__{0!s}__'.format(ropname)
 
     @generic
     def op(x, y):

--- a/src/generic/parametric/base.py
+++ b/src/generic/parametric/base.py
@@ -96,11 +96,11 @@ class ParametricMeta(abc.ABCMeta):
 
     def __call__(self, *args, **kwds):
         if self.__abstract__:
-            raise TypeError('cannot instantiate %s' % self.__name__)
+            raise TypeError('cannot instantiate {0!s}'.format(self.__name__))
         elif self.__origin__ is None:
             new = self.__abstract_new__(*args, **kwds)
             if new.__class__ is self:
-                raise TypeError('cannot instantiate %s' % self.__name__)
+                raise TypeError('cannot instantiate {0!s}'.format(self.__name__))
             return new
         else:
             return super(ParametricMeta, self).__call__(*args, **kwds)
@@ -109,7 +109,7 @@ class ParametricMeta(abc.ABCMeta):
         try:
             return self.__subtypes__[params]
         except TypeError:
-            raise TypeError('%s cannot be parametrized' % self.__name__)
+            raise TypeError('{0!s} cannot be parametrized'.format(self.__name__))
         except KeyError:
             pass
 
@@ -153,7 +153,7 @@ class ParametricMeta(abc.ABCMeta):
         params = _normalize_params(self, params)
         
         if self.__subtypes__ is None:
-            raise TypeError('cannot assign subtypes to %s' % self.__name__)
+            raise TypeError('cannot assign subtypes to {0!s}'.format(self.__name__))
         if params in self.__subtypes__:
             raise KeyError('cannot override to an existing type')
         
@@ -184,7 +184,7 @@ def _check_parameters(origin, params):
         if y is not None or y is not Ellipsis:
             if not isinstance(y, x):
                 tname = x.__name__
-                raise ValueError('expected a %s instance, got %r' % (tname, y))
+                raise ValueError('expected a {0!s} instance, got {1!r}'.format(tname, y))
 
 
 def _normalize_params(origin, params):
@@ -257,7 +257,7 @@ def _subtype_name(origin, params):
     else:
         out.append('?')
     
-    return '%s[%s]'  % (origin.__name__,  ', '.join(out))
+    return '{0!s}[{1!s}]'.format(origin.__name__, ', '.join(out))
 
 
 class Parametric(ABC, metaclass=ParametricMeta):

--- a/src/generic/parametric/containers.py
+++ b/src/generic/parametric/containers.py
@@ -33,7 +33,7 @@ class List(Parametric, list):
         if all(isinstance(x, T) for x in data):
             super().__init__(data)
         else:
-            raise TypeError('contain non-%s elements' % T.__name__)
+            raise TypeError('contain non-{0!s} elements'.format(T.__name__))
 
     def __setitem__(self, item, value):
         T = self.dtype
@@ -60,7 +60,7 @@ class List(Parametric, list):
 
     def __raise_value_insertion_error(self, value):
         fmt = type(value).__name__, type(self).__name__
-        raise TypeError('cannot insert %s values on %s' % fmt)
+        raise TypeError('cannot insert {0!s} values on {1!s}'.format(*fmt))
 
 
 class Dict(Parametric, dict):

--- a/src/generic/parametric/typeparams.py
+++ b/src/generic/parametric/typeparams.py
@@ -69,8 +69,8 @@ class GenericMeta(GenericMeta):
                 if isinstance(base, TypingMeta):
                     if not isinstance(base, typing.GenericMeta):
                         raise TypeError(
-                            "You cannot inherit from magic class %s" %
-                            repr(base))
+                            "You cannot inherit from magic class {0!s}".format(
+                            repr(base)))
                     if base.__parameters__ is None:
                         continue  # The base is unparameterized.
                     for bp in base.__parameters__:
@@ -110,8 +110,7 @@ class GenericMeta(GenericMeta):
                     "All type variables in Generic[...] must be distinct.")
         else:
             if len(params) != len(self.__parameters__):
-                raise TypeError("Cannot change parameter count from %d to %d" %
-                                (len(self.__parameters__), len(params)))
+                raise TypeError("Cannot change parameter count from {0:d} to {1:d}".format(len(self.__parameters__), len(params)))
             for new, old in zip(params, self.__parameters__):
                 if isinstance(old, TypeVar):
                     if not old.__constraints__:
@@ -122,8 +121,7 @@ class GenericMeta(GenericMeta):
                         continue
                 if not issubclass(new, old):
                     raise TypeError(
-                        "Cannot substitute %s for %s in %s" %
-                        (_type_repr(new), _type_repr(old), self))
+                        "Cannot substitute {0!s} for {1!s} in {2!s}".format(_type_repr(new), _type_repr(old), self))
 
         return self.__class__(self.__name__, self.__bases__,
                               dict(self.__dict__),

--- a/src/generic/tests/test_conversions.py
+++ b/src/generic/tests/test_conversions.py
@@ -15,7 +15,7 @@ def T1():
             return NotImplemented
 
         def __repr__(self):
-            return 'T1(%r)' % self.data
+            return 'T1({0!r})'.format(self.data)
 
     return T1
 
@@ -32,7 +32,7 @@ def T2():
             return NotImplemented
 
         def __repr__(self):
-            return 'T2(%r)' % self.data
+            return 'T2({0!r})'.format(self.data)
 
     return T2
 

--- a/src/generic/tests/test_documentation.py
+++ b/src/generic/tests/test_documentation.py
@@ -40,7 +40,7 @@ def add_manuel_suite():
     names = globals()
     suite = manuel.testing.TestSuite(m, *files)
     for i, test in enumerate(suite):
-        name = 'test_manuel_example_%s' % i
+        name = 'test_manuel_example_{0!s}'.format(i)
         names[name] = _factory(test.runTest, name)
     return suite
 

--- a/src/generic/tests/test_operator.py
+++ b/src/generic/tests/test_operator.py
@@ -12,7 +12,7 @@ def T():
             return T(self.data + other.data)
         
         def __repr__(self):
-            return 'T(%s)' % self.data
+            return 'T({0!s})'.format(self.data)
         
         def __eqsame__(self, other):
             return self.data == other.data

--- a/src/generic/tree.py
+++ b/src/generic/tree.py
@@ -39,14 +39,14 @@ class Tree(object):
     def __repr__(self):
         tname = type(self).__name__
         N = len(self.tail)
-        return '<%s (%r) with %s sub-trees>' % (tname, self.head, N)
+        return '<{0!s} ({1!r}) with {2!s} sub-trees>'.format(tname, self.head, N)
 
     def pprint(self):
         '''Return a string with a pretty-printed version of the tree'''
 
         out = [str(self)]
         leaves = [(4 * len(i), i, x.head) for i, x in self.walkitems(True)]
-        leaves = ['%s%r: %r' % (' ' * n, list(i), head) for
+        leaves = ['{0!s}{1!r}: {2!r}'.format(' ' * n, list(i), head) for
                   (n, i, head) in leaves]
         out.extend(leaves)
         return '\n'.join(out)
@@ -236,7 +236,7 @@ class OrderedTree(Tree):
         for index, sub in self.walkitems():
             if sub is subtree:
                 return index
-        raise IndexError('not found in tree: %r' % subtree)
+        raise IndexError('not found in tree: {0!r}'.format(subtree))
 
 
 class PosetMap(collections.MutableMapping):
@@ -296,9 +296,9 @@ class PosetMap(collections.MutableMapping):
         try:
             func = self.tree.ordering.__name__
         except:
-            func = '%s object' % type(self.tree.ordering).__name__
-        data = ', '.join('%r: %r' % item for item in self.iteritems())
-        return 'PosetMap(%s, %s)' % (func, data)
+            func = '{0!s} object'.format(type(self.tree.ordering).__name__)
+        data = ', '.join('{0!r}: {1!r}'.format(*item) for item in self.iteritems())
+        return 'PosetMap({0!s}, {1!s})'.format(func, data)
 
     def iteritems(self):
         for node in self.tree.walk():

--- a/src/generic/util.py
+++ b/src/generic/util.py
@@ -15,7 +15,7 @@ def print_signature(func, types):
 
     fname = func.__name__
     args = ', '.join(T.__name__ for T in types)
-    return '%s(%s)' % (fname, args)
+    return '{0!s}({1!s})'.format(fname, args)
 
 def tname(x):
     '''A shortcut to the object's type name'''

--- a/tasks.py
+++ b/tasks.py
@@ -37,11 +37,11 @@ def py2src():
             fixes = fixes.split()
     else:
         fixes = list(fixes)
-    fixes = ' '.join('-f %s' % fix for fix in fixes)
+    fixes = ' '.join('-f {0!s}'.format(fix) for fix in fixes)
 
     # Move source to py2src folder and patch encoding
     run('cp src/ py2src/ -R')
-    run('3to2 py2src/ --no-diffs -j4 -w %s' % fixes)
+    run('3to2 py2src/ --no-diffs -j4 -w {0!s}'.format(fixes))
 
 
 @task


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:fabiommendes:pygeneric?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:fabiommendes:pygeneric?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
